### PR TITLE
Chain events for oneMKL back end

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,6 +34,9 @@ jobs:
       matrix:
         maker: [cmake, spack]
         device: [gpu_nvidia, gpu_intel]
+        exclude: # spack package doesn't support gpu_intel
+          - maker: spack
+            device: gpu_intel
       fail-fast: false
     runs-on: ${{matrix.device}}
     timeout-minutes: 30

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       matrix:
         maker: [cmake, spack]
-        device: [gpu_nvidia]
+        device: [gpu_nvidia, gpu_intel]
       fail-fast: false
     runs-on: ${{matrix.device}}
     timeout-minutes: 30


### PR DESCRIPTION
This avoids potential races on the working buffers maintained inside the plan shared over all blocks.

Fixes #16