### PR TITLE
Fix AppleClang: Stock `aligned_alloc`

### DIFF
--- a/include/stock_fft/heffte_stock_allocator.h
+++ b/include/stock_fft/heffte_stock_allocator.h
@@ -2,6 +2,7 @@
 #define HEFFTE_STOCK_ALLOCATOR_H
 
 #include <memory>
+#include <stdlib.h>
 #include <vector>
 
 #include "heffte_stock_complex.h"


### PR DESCRIPTION
Compiling heFFTe 2.4.0 with AppleClang 16.0.6 on macOS 13.4 raises:
```
include/stock_fft/heffte_stock_allocator.h:43:46: error: use of undeclared identifier 'aligned_alloc'
            return reinterpret_cast<pointer>(aligned_alloc(alignof(F), n*sizeof(F)));
                                             ^
```

This adds the missing include and uses the C variant of the function (the C++ variant from `<cstdlib>` requires C++17 but heFFTe only uses C++11 so far).

Also, macOS SDK 10.15 or newer is needed: https://stackoverflow.com/a/76984907/2719194

First seen in https://github.com/conda-forge/staged-recipes/pull/26633 for #48 .