### PR TITLE
Fix proc_setup_min_surface bugs in edge cases

### DIFF
--- a/include/heffte_utils.h
+++ b/include/heffte_utils.h
@@ -23,6 +23,7 @@
 #include <deque>
 #include <fstream>
 #include <mpi.h>
+#include <limits>
 
 #include "heffte_config.h"
 


### PR DESCRIPTION
`proc_setup_min_surface` does not give correct grid configurations for edge cases, where one or two dimensions are equal to 1. With this modification, the algorithm respects the global domain size in iterations fixing the abovementioned problem.

Also, the initial grid configuration does not have to be valid, and depending on the problem dimensions, it's even hard to say any valid grid before doing any calculations, as the third dimension can be 1 in 2d problems. Thus in my proposal, it's enough to give any grid and have `best_surface` large enough that any valid grid that is found in the algorithm is better than the initial grid. Setting `best_surface` to `std::numeric_limits<index>::max()` should serve this purpose well.

This PR is related to issue #50.