### PR TITLE
fix proc setup for small problems

### DIFF
--- a/include/heffte_utils.h
+++ b/include/heffte_utils.h
@@ -23,6 +23,7 @@
 #include <deque>
 #include <fstream>
 #include <mpi.h>
+#include <limits>
 
 #include "heffte_config.h"
 


### PR DESCRIPTION
The current version of `proc_setup_min_surface()` assumes that the problem size is large and fails when some of the dimensions have small size (e.g., 1 or 2).

The current algorithm rejects grids that use more ranks than number of entries in any direction.