### PR TITLE
Enabling use of non-cuda environment for CI

### DIFF
--- a/.github/workflows/build-cmake.sh
+++ b/.github/workflows/build-cmake.sh
@@ -6,7 +6,10 @@ BACKEND=$2
 source $(dirname $0)/init.sh
 
 source /apps/spacks/current/github_env/share/spack/setup-env.sh
-spack env activate --without-view heffte2
+
+[ "$BACKEND" = "CUDA" ] && ENV=heffte-cuda || ENV=heffte
+
+spack env activate --without-view $ENV
 
 spack load cmake
 spack load openmpi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
                 *.txt
                 spack-build-*/CMakeFiles/*.log
                 build/CMakeFiles/*.log
-                /tmp/github/spack-stage/spack-stage/heffte-*/spack-build-out.txt
-                /tmp/github/spack-stage/spack-stage/heffte-*/install-time-test-log.txt
+                /tmp/github/spack-stage/spack-*/spack-build-out.txt
+                /tmp/github/spack-stage/spack-*/install-time-test-log.txt
                 .spack/test/*/*.txt
 


### PR DESCRIPTION
This selects a different spack environment for cuda and non-cuda jobs so that the non-cuda jobs do not hit problems when using a cuda-aware MPI (maybe a problem with openmpi).  This allows us to go back to using a 5.x release of OpenMPI.